### PR TITLE
add apex/log adapter for valyala/fasthttp.Logger, fix gometalinter warnings

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,0 +1,7 @@
+{
+  "Linters": {
+    "gocyclo": {"Command": "gocyclo -over 50"}
+  },
+  "EnableAll": true,
+  "EnableGC": true
+}

--- a/app_listenAndServe.go
+++ b/app_listenAndServe.go
@@ -3,9 +3,6 @@ package gramework
 import (
 	"errors"
 	"flag"
-	"log"
-
-	"io/ioutil"
 
 	"github.com/valyala/fasthttp"
 )
@@ -43,7 +40,7 @@ func (app *App) ListenAndServe(addr ...string) error {
 
 	s := fasthttp.Server{
 		Handler: app.handler(),
-		Logger:  fasthttp.Logger(log.New(ioutil.Discard, "", log.LstdFlags)),
+		Logger:  NewFastHTTPLoggerAdapter(&app.Logger),
 		Name:    app.name,
 	}
 	err := s.ListenAndServe(bind)

--- a/app_serve.go
+++ b/app_serve.go
@@ -1,8 +1,6 @@
 package gramework
 
 import (
-	"io/ioutil"
-	"log"
 	"net"
 
 	"github.com/valyala/fasthttp"
@@ -15,7 +13,7 @@ func (app *App) Serve(ln net.Listener) error {
 	}
 	s := fasthttp.Server{
 		Handler: app.handler(),
-		Logger:  fasthttp.Logger(log.New(ioutil.Discard, "", log.LstdFlags)),
+		Logger:  NewFastHTTPLoggerAdapter(&app.Logger),
 		Name:    app.name,
 	}
 	err := s.Serve(ln)

--- a/conv.go
+++ b/conv.go
@@ -7,11 +7,13 @@ import (
 )
 
 // BytesToString effectively converts bytes to string
+// nolint: gas
 func BytesToString(b []byte) string {
 	return *(*string)(unsafe.Pointer(&b))
 }
 
 // StringToBytes effectively converts string to bytes
+// nolint: gas
 func StringToBytes(s string) []byte {
 	strstruct := runtimer.StringStructOf(&s)
 	return *(*[]byte)(unsafe.Pointer(&runtimer.SliceType2{

--- a/fasthttprouter_router_test.go
+++ b/fasthttprouter_router_test.go
@@ -723,7 +723,7 @@ func TestRouterLookup(t *testing.T) {
 	// insert route and try again
 	router.GET("/user/:name", wantHandle)
 
-	handle, tsr = router.defaultRouter.Lookup("GET", "/user/gopher", ctx)
+	handle, _ = router.defaultRouter.Lookup("GET", "/user/gopher", ctx)
 	if handle == nil {
 		t.Fatal("Got no handle!")
 	} else {

--- a/fasthttprouter_tree.go
+++ b/fasthttprouter_tree.go
@@ -106,7 +106,8 @@ func (n *node) addRoute(path string, handle RequestHandler, r *router) {
 			// Find the longest common prefix.
 			// This also implies that the common prefix contains no ':' or '*'
 			// since the existing key can't contain those chars.
-			i := zero
+			var i int
+			i = zero
 			max := min(len(path), len(n.path))
 			for i < max && path[i] == n.path[i] {
 				i++
@@ -181,7 +182,7 @@ func (n *node) addRoute(path string, handle RequestHandler, r *router) {
 				}
 
 				// Check if a child with the next path byte exists
-				for i := zero; i < len(n.indices); i++ {
+				for i = zero; i < len(n.indices); i++ {
 					if c == n.indices[i] {
 						i = n.incrementChildPrio(i)
 						n = n.children[i]

--- a/log.go
+++ b/log.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/cli"
+	"github.com/valyala/fasthttp"
 )
 
 // Logger handles default logger
@@ -16,4 +17,23 @@ var Logger = &log.Logger{
 // Errorf logs an error using default logger
 func Errorf(msg string, v ...interface{}) {
 	Logger.Errorf(msg, v...)
+}
+
+// FastHTTPLoggerAdapter  Adapter for passing apex/log used as gramework Logger into fasthttp
+type FastHTTPLoggerAdapter struct {
+	apexLogger log.Interface
+	fasthttp.Logger
+}
+
+// NewFastHTTPLoggerAdapter create new *FastHTTPLoggerAdapter
+func NewFastHTTPLoggerAdapter(logger *log.Interface) (fasthttplogger *FastHTTPLoggerAdapter) {
+	fasthttplogger = &FastHTTPLoggerAdapter{
+		apexLogger: *logger,
+	}
+	return fasthttplogger
+}
+
+//Printf show message only if set app.Logger.Level = apex/log.DebugLevel
+func (l *FastHTTPLoggerAdapter) Printf(msg string, v ...interface{}) {
+	l.apexLogger.Debugf(msg, v...)
 }

--- a/log_test.go
+++ b/log_test.go
@@ -17,7 +17,8 @@ func TestLogErrorfShouldNotPanic(t *testing.T) {
 }
 
 func TestFastHTTPLoggerAdapter(t *testing.T) {
-	var apexLogger log.Interface = Logger
+	var apexLogger log.Interface
+	apexLogger = Logger
 	logger := NewFastHTTPLoggerAdapter(&apexLogger)
 	logger.Printf("printed")
 }

--- a/log_test.go
+++ b/log_test.go
@@ -1,6 +1,9 @@
 package gramework
 
-import "testing"
+import (
+	"github.com/apex/log"
+	"testing"
+)
 
 func TestLogErrorfShouldNotPanic(t *testing.T) {
 	defer func() {
@@ -11,4 +14,10 @@ func TestLogErrorfShouldNotPanic(t *testing.T) {
 		}
 	}()
 	Errorf("test: %v", []string{"test"})
+}
+
+func TestFastHTTPLoggerAdapter(t *testing.T) {
+	var apexLogger log.Interface = Logger
+	logger := NewFastHTTPLoggerAdapter(&apexLogger)
+	logger.Printf("printed")
 }

--- a/regFlags.go
+++ b/regFlags.go
@@ -35,6 +35,7 @@ func (app *App) RegFlags() {
 	}
 }
 
+// GetStringFlag return command line app flag value by name and false if not exists
 func (app *App) GetStringFlag(name string) (string, bool) {
 	if !flag.Parsed() {
 		flag.Parse()


### PR DESCRIPTION
i add fasthttp.Logger adapter for passing app.Logger into fasthttp
and fix following gometalinter warnigs

```
gramework/regFlags.go:38:1:warning: exported method App.GetStringFlag should have comment or be unexported (golint)
gramework/app_listenAndServeAutoTLS.go:63::warning: declaration of "err" shadows declaration at gramework/app_listenAndServeAutoTLS.go:40 (vetshadow)
gramework/app_listenAndServeAutoTLS.go:128::warning: declaration of "err" shadows declaration at gramework/app_listenAndServeAutoTLS.go:100 (vetshadow)
gramework/fasthttprouter_tree.go:184::warning: declaration of "i" shadows declaration at gramework/fasthttprouter_tree.go:109 (vetshadow)
gramework/conv.go:11::warning: Use of unsafe calls should be audited,LOW,HIGH (gas)
gramework/conv.go:17::warning: Use of unsafe calls should be audited,LOW,HIGH (gas)
gramework/fasthttprouter_router_test.go:726:10:warning: ineffectual assignment to tsr (ineffassign)
```