### PR TITLE
Fix travis golint error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
 before_install:
   - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/)
   - go get -t -v ./...
-  - go get -v github.com/golang/lint/golint
+  - go get -v golang.org/x/lint/golint
   - go get -v honnef.co/go/tools/cmd/megacheck
   - go get -v github.com/fzipp/gocyclo
   - go get -v golang.org/x/tools/cmd/goimports


### PR DESCRIPTION
Travis-ci has some error during `go get -v github.com/golang/lint/golint`. According to [golint doc](https://github.com/golang/lint#installation), we have to use `go get -v golang.org/x/lint/golint` to install golint.

It is not related to code. So, I didn't update version and CHANGELOG.md yet.
If need it, I will update it ASAP.