### PR TITLE
tests: Replace deprecated io/ioutil with os package

### DIFF
--- a/app_router_test.go
+++ b/app_router_test.go
@@ -10,21 +10,19 @@
 package gramework
 
 import (
-	"io/ioutil"
 	"os"
-	"strings"
+	"path/filepath"
 	"testing"
 
 	"github.com/valyala/fasthttp"
 )
 
 func testProvideTempFile(t *testing.T, action func(file, dir string)) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "servedirtmp_")
+	tmpDir := t.TempDir()
+	tmpFile, err := os.CreateTemp(tmpDir, "servedirtmp_")
 	if err != nil {
 		t.Error("cannot create temporary file:", err)
 	}
-
-	defer os.Remove(tmpFile.Name())
 
 	// write some text into file
 	text := []byte("test_file_data")
@@ -36,9 +34,7 @@ func testProvideTempFile(t *testing.T, action func(file, dir string)) {
 		t.Error(err)
 	}
 
-	tempFName := strings.Replace(tmpFile.Name(), os.TempDir(), "", -1)
-
-	action(tempFName, os.TempDir())
+	action(filepath.Base(tmpFile.Name()), tmpDir)
 }
 
 func TestAppServeDir(t *testing.T) {

--- a/fasthttprouter_router_test.go
+++ b/fasthttprouter_router_test.go
@@ -10,7 +10,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -928,9 +927,9 @@ func TestRouterServeFiles(t *testing.T) {
 		t.Fatal("registering path not ending with '*filepath' did not panic")
 	}
 	body := []byte("fake ico")
-	err := ioutil.WriteFile(os.TempDir()+"/favicon.ico", body, 0644)
+	err := os.WriteFile(os.TempDir()+"/favicon.ico", body, 0644)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	router.defaultRouter.ServeFiles("/*filepath", os.TempDir())

--- a/test/behind_test/main.go
+++ b/test/behind_test/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/gramework/gramework"
 	"github.com/gramework/gramework/behind/akamai"
@@ -10,7 +10,7 @@ import (
 func main() {
 	app := gramework.New()
 
-	csv, err := ioutil.ReadFile("./testdata/all-cidr-blocks.csv")
+	csv, err := os.ReadFile("./testdata/all-cidr-blocks.csv")
 	must(err)
 	akamCIDR, err := akamai.ParseCIDRBlocksCSV(csv, true, true)
 	must(err)

--- a/test/gramework_test.go
+++ b/test/gramework_test.go
@@ -14,7 +14,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"reflect"
@@ -389,7 +388,7 @@ func TestSPAIndexHandler(t *testing.T) {
 		t.FailNow()
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("Gramework isn't working! Can't read body: %s", err)
 		t.FailNow()


### PR DESCRIPTION
This PR replaces the usages of deprecated `io/ioutil` package with `os`.

From the [doc](https://pkg.go.dev/io/ioutil):
> Deprecated: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.

Changes explanation:

- `T.TempDir` allows us to avoid manually removing the temp file because the directory is automatically removed by Cleanup when the test and all its subtests complete. See [the doc](https://pkg.go.dev/testing#T.TempDir).
- `filepath.Base` is a better way for determining the last element of a path.